### PR TITLE
Fix command function

### DIFF
--- a/Source/IO/Read.php
+++ b/Source/IO/Read.php
@@ -2,33 +2,51 @@
 
 namespace PhpRepos\Cli\IO\Read;
 
+/**
+ * Get a specific command-line argument by its position.
+ *
+ * This function retrieves a command-line argument based on its position, allowing you
+ * to access arguments passed to the script. You can specify a default value that will
+ * be returned if the argument is not provided.
+ *
+ * @param int $number The position of the argument (0-based).
+ * @param string|null $default The default value if the argument is not provided.
+ * @return string|null The value of the specified argument or the default value if not provided.
+ */
 function argument(int $number, ?string $default = null): ?string
 {
     global $argv;
 
-    $inputs = [];
+    // Filter out arguments starting with '-' (assumes no positional arguments start with '-')
+    $inputs = array_filter($argv, function ($userInput) {
+        return !str_starts_with($userInput, '-');
+    });
 
-    foreach ($argv as $userInput) {
-        if (! str_starts_with($userInput, '-')) {
-            $inputs[] = $userInput;
-        }
-    }
-
-    unset($inputs[0]);
+    unset($inputs[0]); // Remove script name
 
     return $inputs[$number] ?? $default;
 }
 
+/**
+ * Get the main command from the command-line arguments.
+ *
+ * This function helps you retrieve the main command passed to the script, excluding
+ * any options or other arguments. It is useful when you want to determine the primary
+ * action that the script should take.
+ *
+ * @return string|null The main command or null if not provided.
+ */
 function command(): ?string
 {
     global $argv;
 
+    // Skip the script name (index 0) and return the first non-option argument
     foreach ($argv as $index => $argument) {
         if ($index === 0) {
             continue;
         }
 
-        if (! str_starts_with($argument, '-')) {
+        if (!str_starts_with($argument, '-')) {
             return $argument;
         }
     }
@@ -36,6 +54,17 @@ function command(): ?string
     return null;
 }
 
+/**
+ * Get a specific named parameter from the command-line arguments.
+ *
+ * This function allows you to retrieve a named parameter from the command-line
+ * arguments using the double-dash format, e.g., "--param=value". You can specify
+ * a default value that will be returned if the parameter is not provided.
+ *
+ * @param string $name The name of the parameter (without leading dashes).
+ * @param string|null $default The default value if the parameter is not provided.
+ * @return string|null The value of the specified parameter or the default value if not provided.
+ */
 function parameter(string $name, ?string $default = null): ?string
 {
     $input = getopt('', [$name . '::']);
@@ -43,6 +72,7 @@ function parameter(string $name, ?string $default = null): ?string
     if (count($input) === 0) {
         global $argv;
 
+        // Search for the named parameter and extract its value
         $input = array_reduce($argv, function ($carry, $argument) use ($name) {
             return str_starts_with($argument, "--$name=")
                 ? [$name => str_replace("--$name=", '', $argument)]
@@ -53,22 +83,30 @@ function parameter(string $name, ?string $default = null): ?string
     return $input[$name] ?? $default;
 }
 
+/**
+ * Check if a specific named option is present in the command-line arguments.
+ *
+ * This function allows you to check whether a named option (flag) is present
+ * in the command-line arguments. The option can be specified using single or
+ * double dashes (e.g., "--flag" or "-f").
+ *
+ * @param string $name The name of the option (without leading dashes).
+ * @return bool Whether the specified option is present.
+ */
 function option(string $name): bool
 {
     global $argv;
 
-    $option = false;
-
+    // Check if the option is present in any of the arguments
     foreach ($argv as $input) {
         if (
             $input === '--' . $name
             || str_starts_with($input, '--' . $name . '=')
             || $input === '-' . $name
         ) {
-            $option = true;
-            break;
+            return true;
         }
     }
 
-    return $option;
+    return false;
 }

--- a/Source/IO/Read.php
+++ b/Source/IO/Read.php
@@ -23,7 +23,17 @@ function command(): ?string
 {
     global $argv;
 
-    return ! isset($argv[1]) || str_starts_with($argv[1], '-') ? null : $argv[1];
+    foreach ($argv as $index => $argument) {
+        if ($index === 0) {
+            continue;
+        }
+
+        if (! str_starts_with($argument, '-')) {
+            return $argument;
+        }
+    }
+
+    return null;
 }
 
 function parameter(string $name, ?string $default = null): ?string

--- a/Source/IO/Write.php
+++ b/Source/IO/Write.php
@@ -4,41 +4,116 @@ namespace PhpRepos\Cli\IO\Write;
 
 use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
 
+/**
+ * Output a message to the console.
+ *
+ * This function prints the provided message to the console without any additional formatting.
+ *
+ * @param string $message The message to be displayed.
+ * @return void
+ */
 function output(string $message): void
 {
     echo $message;
 }
 
+/**
+ * Assert that the output matches the expected value.
+ *
+ * This function performs an assertion to check if the actual output matches the expected value.
+ * If the assertion fails, an error message is provided as the second argument of assert_true().
+ *
+ * @param string $expected The expected output value.
+ * @param string $actual The actual output value.
+ * @return bool Whether the assertion passed (true) or failed (false).
+ */
 function assert_output(string $expected, string $actual): bool
 {
     return assert_true($actual === $expected, "Can not see '$expected' in '$actual'.");
 }
 
+/**
+ * Output a line of text to the console with default text color.
+ *
+ * This function prints a line of text to the console, with default text color (reset to normal).
+ *
+ * @param string $string The text to be displayed.
+ * @return void
+ */
 function line(string $string): void
 {
     output("\e[39m$string" . PHP_EOL);
 }
 
+/**
+ * Assert that the output line matches the expected value with default text color.
+ *
+ * This function performs an assertion to check if the actual output line (with default text color)
+ * matches the expected value. If the assertion fails, an error message is provided as the second
+ * argument of assert_true().
+ *
+ * @param string $expected The expected output line.
+ * @param string $actual The actual output value.
+ * @return bool Whether the assertion passed (true) or failed (false).
+ */
 function assert_line(string $expected, string $actual): bool
 {
     return assert_output("\e[39m$expected" . PHP_EOL, $actual);
 }
 
+/**
+ * Output a success message to the console with green text color.
+ *
+ * This function prints a success message to the console with green text color, indicating a successful operation.
+ *
+ * @param string $string The success message to be displayed.
+ * @return void
+ */
 function success(string $string): void
 {
     output("\e[92m$string\e[39m" . PHP_EOL);
 }
 
+/**
+ * Assert that the success message matches the expected value with green text color.
+ *
+ * This function performs an assertion to check if the actual success message (with green text color)
+ * matches the expected value. If the assertion fails, an error message is provided as the second
+ * argument of assert_true().
+ *
+ * @param string $expected The expected success message.
+ * @param string $actual The actual output value.
+ * @return bool Whether the assertion passed (true) or failed (false).
+ */
 function assert_success(string $expected, string $actual): bool
 {
     return assert_output("\e[92m$expected\e[39m" . PHP_EOL, $actual);
 }
 
+/**
+ * Output an error message to the console with red text color.
+ *
+ * This function prints an error message to the console with red text color, indicating an error condition.
+ *
+ * @param string $string The error message to be displayed.
+ * @return void
+ */
 function error(string $string): void
 {
     output("\e[91m$string\e[39m" . PHP_EOL);
 }
 
+/**
+ * Assert that the error message matches the expected value with red text color.
+ *
+ * This function performs an assertion to check if the actual error message (with red text color)
+ * matches the expected value. If the assertion fails, an error message is provided as the second
+ * argument of assert_true().
+ *
+ * @param string $expected The expected error message.
+ * @param string $actual The actual output value.
+ * @return bool Whether the assertion passed (true) or failed (false).
+ */
 function assert_error(string $expected, string $actual): bool
 {
     return assert_output("\e[91m$expected\e[39m"  . PHP_EOL, $actual);

--- a/Tests/IO/ReadTest.php
+++ b/Tests/IO/ReadTest.php
@@ -27,6 +27,9 @@ test(
         $output = shell_exec(__DIR__ . '/../../TestRequirements/ReadCommandHelper.php ' . $command);
         assert_true($output === $command, $output);
 
+        $output = shell_exec(__DIR__ . '/../../TestRequirements/ReadCommandHelper.php --params="does not have effect" ' . $command);
+        assert_true($output === $command, $output);
+
         $output = shell_exec(__DIR__ . '/../../TestRequirements/ReadCommandHelper.php --command=' . $command);
         assert_true(is_null($output), $output);
 


### PR DESCRIPTION

Previously, the command function was returning the first argv as the command. This PR adds the ability to go through passed argv and find the first passed argument that does not start with - and return it as the command.